### PR TITLE
feat: add all models seeders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -348,6 +348,11 @@
       "resolved": "https://registry.npmjs.org/bcrypt-nodejs/-/bcrypt-nodejs-0.0.3.tgz",
       "integrity": "sha1-xgkX8m3CNWYVZsaBBhwwPCsohCs="
     },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "bcrypt-nodejs": "0.0.3",
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",
     "chai": "^4.2.0",
     "connect-flash": "^0.1.1",

--- a/seeders/20230606061719-user-seeder.js
+++ b/seeders/20230606061719-user-seeder.js
@@ -1,0 +1,44 @@
+const bcrypt = require('bcryptjs')
+const faker = require('faker')
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert(
+      'Users',
+      Array.from({ length: 10 }, (_, i) =>
+        i === 0
+          ? {
+              // admin account
+              email: 'root@example.com',
+              account: 'root',
+              password: bcrypt.hashSync('12345678', 10), // 直接使用hashSync同步生成hash
+              role: 'admin',
+              name: 'root',
+              avatar: `https://i.pravatar.cc/300?img=${Math.floor(Math.random() * 100)}`,
+              introduction: faker.lorem.words(5),
+              cover: `https://loremflickr.com/640/480/city?lock=${Math.floor(Math.random() * 100)}`,
+              createdAt: new Date(),
+              updatedAt: new Date()
+            }
+          : {
+              // at least 5 users
+              email: `user${i}@example.com`,
+              account: `user${i}`,
+              password: bcrypt.hashSync('12345678', 10),
+              name: `user${i}`,
+              avatar: `https://i.pravatar.cc/300?img=${Math.floor(Math.random() * 100)}`,
+              introduction: faker.lorem.words(5),
+              cover: `https://loremflickr.com/640/480/city?lock=${Math.floor(Math.random() * 100)}`,
+              createdAt: new Date(),
+              updatedAt: new Date()
+            }
+      ),
+      {}
+    )
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    // 清空資料表中所有資料
+    await queryInterface.bulkDelete('Users', {})
+  }
+}

--- a/seeders/20230606074720-add-tweets-seeders.js
+++ b/seeders/20230606074720-add-tweets-seeders.js
@@ -1,0 +1,32 @@
+'use strict'
+const faker = require('faker')
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // find user id first and exclude admin account
+    const users = await queryInterface.sequelize.query(
+      "SELECT id FROM Users WHERE name <> 'root'", // WHERE role <> 'admin'找不到東西
+      {
+        type: queryInterface.sequelize.QueryTypes.SELECT
+      }
+    )
+    const tweets = [] // add this variable in to table
+    users.forEach(user => {
+      tweets.push(
+        ...Array.from({ length: 10 }, (_, i) => ({
+          UserId: user.id,
+          description: faker.lorem.paragraph(1).slice(0, 140),
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }))
+      )
+    })
+    await queryInterface.bulkInsert('Tweets',
+      tweets
+    )
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Tweets', {})
+  }
+}

--- a/seeders/20230606083101-add-replies-seeders.js
+++ b/seeders/20230606083101-add-replies-seeders.js
@@ -1,0 +1,32 @@
+'use strict'
+const faker = require('faker')
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const users = await queryInterface.sequelize.query(
+      "SELECT id FROM Users WHERE name <> 'root'", // WHERE role <> 'admin'找不到東西
+      { type: queryInterface.sequelize.QueryTypes.SELECT }
+    )
+    const tweets = await queryInterface.sequelize.query(
+      'SELECT id FROM Tweets',
+      { type: queryInterface.sequelize.QueryTypes.SELECT }
+    )
+    const replies = []
+    tweets.forEach(tweet => {
+      replies.push(
+        ...Array.from({ length: 3 }, (_, i) => ({
+          UserId: users[Math.floor(Math.random() * users.length)].id,
+          TweetId: tweet.id,
+          comment: faker.lorem.paragraph(1),
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }))
+      )
+    })
+
+    await queryInterface.bulkInsert('Replies', replies)
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Replies', {})
+  }
+}

--- a/seeders/20230606084457-add-likes-seeders.js
+++ b/seeders/20230606084457-add-likes-seeders.js
@@ -1,0 +1,40 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // find user id first and exclude admin account
+    const users = await queryInterface.sequelize.query(
+      "SELECT id FROM Users WHERE name <> 'root';", // WHERE role <> 'admin'找不到東西
+      { type: queryInterface.sequelize.QueryTypes.SELECT }
+    )
+    // find all tweets id
+    const tweets = await queryInterface.sequelize.query(
+      'SELECT id FROM Tweets;',
+      { type: queryInterface.sequelize.QueryTypes.SELECT }
+    )
+
+    const likes = []
+    // Each user randomly likes 3 tweets
+    const numOfLikes = 3
+    users.forEach(user => {
+      const unlikeTweets = tweets.map(tweet => tweet.id)
+      for (let i = 0; i < numOfLikes; i++) {
+        const randomIndex = Math.floor(Math.random() * unlikeTweets.length)
+        likes.push({
+          UserId: user.id,
+          TweetId: unlikeTweets[randomIndex],
+          isLike: true,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+        // avoid to like same tweet
+        unlikeTweets.splice(randomIndex, 1)
+      }
+    })
+    await queryInterface.bulkInsert('Likes', likes)
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Likes', {})
+  }
+}

--- a/seeders/20230606084513-add-followship-seeders.js
+++ b/seeders/20230606084513-add-followship-seeders.js
@@ -1,0 +1,36 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    // find user id first and exclude admin account
+    const users = await queryInterface.sequelize.query(
+      "SELECT id FROM Users WHERE name <> 'root';", // WHERE role <> 'admin'找不到東西
+      { type: queryInterface.sequelize.QueryTypes.SELECT }
+    )
+
+    const followships = []
+    // Each user randomly follows 2 users
+    const numOfFollowing = 2
+    users.forEach(user => {
+      // avoid to follow self
+      const excludeSelfUsers = users.filter(u => u.id !== user.id)
+
+      for (let i = 0; i < numOfFollowing; i++) {
+        const randomIndex = Math.floor(Math.random() * excludeSelfUsers.length)
+        followships.push({
+          followerId: user.id,
+          followingId: excludeSelfUsers[randomIndex].id,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+        // avoid to follow same user
+        excludeSelfUsers.splice(randomIndex, 1)
+      }
+    })
+    await queryInterface.bulkInsert('Followships', followships)
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Followships', {})
+  }
+}


### PR DESCRIPTION
已新增種子資料檔，請直接執行 npx sequelize db:seed:all
除了AC指定種子資料：
1. 指定admin登入帳號 account: root, email:root@example.com, password: 12345678
2. 至少5位使用者且其中一位須為account: user1, email:user1@example.com, password: 12345678
3. 每個使用者有 10 篇 tweet
4. 每篇 tweet 有隨機 3 個留言者，每個人有 1 則留言

額外再新增了 Likes 和 Followships的種子資料：
1. 每位使用者隨機Like 3篇tweets
2. 每位使用者隨機追蹤2名其它使用者

**問題討論：**
1. 目前有盡可能排除可能會重複追蹤、重複like的狀況發生
2. 已發現尚未解決的問題：要找出資料庫現有userId時，若條件
使用WHERE role <> 'admin會找不到資料，暫時改用WHERE name <> 'root'代替，如下

`const users = await queryInterface.sequelize.query(
      "SELECT id FROM Users WHERE name <> 'root';", // WHERE role <> 'admin'找不到東西
      { type: queryInterface.sequelize.QueryTypes.SELECT }
    )`