### PR TITLE
feat: read room

### DIFF
--- a/socket/index.js
+++ b/socket/index.js
@@ -5,7 +5,7 @@ const disconnect = require('./modules/disconnect')
 const record = require('./modules/record')
 const getRoom = require('./modules/getRoom')
 const newMessage = require('./modules/newMessage')
-const enterRoom = require('./modules/enterRoom')
+const read = require('./modules/read')
 
 module.exports = io => {
   io.on('connection', socket => {
@@ -25,8 +25,8 @@ module.exports = io => {
     socket.on('client-new-message', () => newMessage(io, socket))
     // 取得我跟目標的roomId
     socket.on('client-get-room', targetId => getRoom(io, socket, targetId))
-    // 使用者進入一個房間(紀錄最後讀取時間)
-    socket.on('client-enter-room', room => enterRoom(socket, room))
+    // 紀錄最後讀取時間
+    socket.on('client-read', room => read(socket, room))
 
     // 使用者斷線
     socket.on('disconnect', reason => disconnect(io, socket, reason))


### PR DESCRIPTION
把 client-enter-room / client-leave-room 統一改成 client-read, 讓前端自己控制什麼時候使用，就不會有離開房間，加入房間這種概念，完全讓前端決定什麼時候使用，這樣比較彈性，例如：

- 打開跟Ａ聊天視窗時觸發一次 client-read(跟Ａ的房間)
- 關掉跟Ａ聊天視窗時觸發一次 client-read(跟Ａ的房間)
- 切換頁面到別的頁面時觸發一次
- socket disconnect 時觸發一次
- 要是從跟Ａ的聊天視窗，切換到跟Ｂ的聊天視窗就要兩個房間都觸發一次

回傳 server-read
{
    "userId": 2,
    "roomId": 3,
    "time": "2023-07-12T08:03:09.003Z"
}