### PR TITLE
refactor: join and leave use userId

### DIFF
--- a/socket/helper/index.js
+++ b/socket/helper/index.js
@@ -1,6 +1,5 @@
 // 用來驗證一些基本問題
 
-const { raw } = require('body-parser')
 const { User, Room } = require('../../models')
 const usersInPublic = require('../modules/userOnline')
 const { Op } = require('sequelize')
@@ -10,8 +9,6 @@ const helper = {
   userExistInDB: async (input, typeString) => {
     if (typeString === 'id') input = Number(input)
     const whereCondition = { [typeString]: input }
-    // if typeString = id, but input is string, Error of NaN
-
     const user = await User.findOne({
       where: whereCondition,
       attributes: ['id', 'account', 'name', 'avatar']

--- a/socket/index.js
+++ b/socket/index.js
@@ -12,9 +12,9 @@ module.exports = io => {
     console.log(socket.id)
 
     // 上線
-    socket.on('client-join', account => join(io, socket, account))
+    socket.on('client-join', userId => join(io, socket, userId))
     // 離線
-    socket.on('client-leave', account => leave(io, socket, account))
+    socket.on('client-leave', userId => leave(io, socket, userId))
     // 傳送訊息
     socket.on('client-message', (message, time, roomId) =>
       sendMessage(io, socket, message, time, roomId)

--- a/socket/modules/leave.js
+++ b/socket/modules/leave.js
@@ -1,17 +1,16 @@
 const usersInPublic = require('./userOnline')
 const { userExistInDB, findUserInPublic, findUserIndexInPublic, emitError } = require('../helper')
 
-module.exports = async (io, socket, userAccount) => {
+module.exports = async (io, socket, userId) => {
   try {
-    // 檢查 使用者存在
-    const user = await userExistInDB(userAccount, 'account')
+    const user = await userExistInDB(userId, 'id')
 
     // 檢查 使用者在不在上線名單上 (暫時傳錯誤給postman)
-    const userOnline = findUserInPublic(user.account, 'account', false)
+    const userOnline = findUserInPublic(userId, 'id', false)
     if (!userOnline) throw new Error('使用者已經不在上線名單上！(已下線)')
 
     // 從上線名單移除使用者
-    usersInPublic.splice(findUserIndexInPublic(user.account, 'account'), 1)
+    usersInPublic.splice(findUserIndexInPublic(userId, 'id'), 1)
 
     // 給全部使用者 更新的上線名單
     socket.broadcast.emit('server-update', usersInPublic)


### PR DESCRIPTION
change join/ leave event to use userId instead of account

- also change
- when join, always get the User in database, to ensure the user data is newest
- Both reconnect and new join will update the user data in the userOnList (上線名單)
- Both reconnect and new join will emit a server-update to all users