### PR TITLE
fix: record, new-message now only send to related users

### DIFF
--- a/socket/helper/index.js
+++ b/socket/helper/index.js
@@ -26,7 +26,7 @@ const helper = {
     const currentUser = usersInPublic.find(user => user[typeString] === input)
     // 需不需要檢查存在
     if (!checkExist) return currentUser
-    if (!currentUser) throw new Error('you need to use client-join first')
+    if (!currentUser) throw new Error(`Can not find user with user.[${typeString}]=${input}, or you need to use client-join first`)
     return currentUser
   },
   filterUsersInPublic: (input, typeString, checkExist = true) => {

--- a/socket/index.js
+++ b/socket/index.js
@@ -21,9 +21,9 @@ module.exports = io => {
       sendMessage(io, socket, message, time, roomId)
     )
     // 歷史訊息
-    socket.on('client-record', room => record(io, socket, room))
+    socket.on('client-record', room => record(socket, room))
     // 私人聊天室的最新訊息
-    socket.on('client-new-message', () => newMessage(io, socket))
+    socket.on('client-new-message', () => newMessage(socket))
     // 取得我跟目標的roomId
     socket.on('client-get-room', targetId => getRoom(io, socket, targetId))
 

--- a/socket/modules/newMessage.js
+++ b/socket/modules/newMessage.js
@@ -2,7 +2,7 @@ const { emitError, findUserInPublic } = require('../helper')
 const { Chat, User, Read } = require('../../models')
 const { Op } = require('sequelize')
 
-module.exports = async (io, socket) => {
+module.exports = async socket => {
   try {
     // 確認使用者是否登入
     const currentUser = findUserInPublic(socket.id, 'socketId')
@@ -39,7 +39,7 @@ module.exports = async (io, socket) => {
     message.forEach(m => {
       // 確認此聊天室是否有read紀錄
       const isReadExist = reads.find(r => r.roomId === m.roomId)
-      // 如果沒有紀錄，或是lastread<timestamp
+      // 如果沒有紀錄，或是last read < timestamp
       if (!isReadExist || isReadExist?.lastRead < m.timestamp) {
         unread[m.roomId] += 1
       }
@@ -58,8 +58,8 @@ module.exports = async (io, socket) => {
       unreadMessageCounts: unread[n.roomId]
     }))
 
-    // 回傳最新訊息&未讀總數
-    io.emit('server-new-message', { newMessageData, allUnreadMessageCounts })
+    // 回傳最新訊息&未讀總數 (只傳給socket本人)
+    socket.emit('server-new-message', { newMessageData, allUnreadMessageCounts })
   } catch (err) {
     emitError(socket, err)
   }

--- a/socket/modules/record.js
+++ b/socket/modules/record.js
@@ -1,7 +1,7 @@
 const { emitError } = require('../helper')
 const { Chat, User, Room } = require('../../models')
 
-module.exports = async (io, socket, roomId) => {
+module.exports = async (socket, roomId) => {
   try {
     // 如未傳入值，預設為public room
     if (!roomId) {
@@ -23,7 +23,7 @@ module.exports = async (io, socket, roomId) => {
     records = records.length ? records : '尚未聊天過，開始發送訊息吧!'
 
     // 回傳歷史訊息
-    io.emit('server-record', records)
+    socket.emit('server-record', records)
   } catch (err) {
     emitError(socket, err)
   }


### PR DESCRIPTION
更新：
- client-message : 私人訊息會觸發在 房間內 全部使用者的 read 跟 client-new-message
- client-message : 需要使用 client-enter-room 後才能使用 (需要自動觸發)

Bug Fix：
- client-record send to everyone (change to only the user)
- client-new-message send to everyone  (change to only current in room users)
- client-message trigger read to everyone online (change to only current in room users)