### PR TITLE
Unread notice

### DIFF
--- a/seeders/20230720054920-add-notice-seeder.js
+++ b/seeders/20230720054920-add-notice-seeder.js
@@ -1,0 +1,23 @@
+'use strict'
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const users = await queryInterface.sequelize.query(
+      "SELECT id FROM Users WHERE role <> 'admin'",
+      { type: queryInterface.sequelize.QueryTypes.SELECT }
+    )
+
+    const notices = users.map(user => ({
+      userId: user.id,
+      newNotice: null,
+      noticeRead: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }))
+
+    await queryInterface.bulkInsert('Notices', notices)
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Notices', {})
+  }
+}

--- a/socket/helper/index.js
+++ b/socket/helper/index.js
@@ -68,16 +68,7 @@ const helper = {
   checkNotice: async userId => {
     const notice = await Notice.findOne({ where: { userId } })
     // if notice exist
-    if (notice) return notice.newNotice > notice.noticeRead
-    // if there isn't any notice record, create a new one and return false
-    await Notice.create({
-      userId,
-      newNotice: null,
-      noticeRead: null,
-      createdAt: new Date(),
-      updatedAt: new Date()
-    })
-    return false
+    return notice.newNotice > notice.noticeRead
   },
   findAllSubscribers: async userId => {
     const subscribers = await Subscribe.findAll({

--- a/socket/helper/index.js
+++ b/socket/helper/index.js
@@ -1,5 +1,5 @@
 // 用來驗證一些基本問題
-const { User, Room, Notice } = require('../../models')
+const { User, Room, Notice, Subscribe } = require('../../models')
 const usersInPublic = require('../modules/userOnline')
 const { Op } = require('sequelize')
 
@@ -69,8 +69,18 @@ const helper = {
     const notice = await Notice.findOne({ where: { userId } })
     // if notice exist
     if (notice) return notice.newNotice > notice.noticeRead
-    // if there isn't any notice record
+    // if there isn't any notice record, create a new one and return false
+    await Notice.create({ userId, newNotice: new Date(), noticeRead: new Date() })
     return false
+  },
+  findAllSubscribers: async userId => {
+    const subscribers = await Subscribe.findAll({
+      where: { toUserId: userId },
+      attributes: ['fromUserId'],
+      raw: true
+    })
+    const subscribersId = subscribers.map(s => s.fromUserId)
+    return subscribersId
   }
 }
 module.exports = helper

--- a/socket/helper/index.js
+++ b/socket/helper/index.js
@@ -70,7 +70,13 @@ const helper = {
     // if notice exist
     if (notice) return notice.newNotice > notice.noticeRead
     // if there isn't any notice record, create a new one and return false
-    await Notice.create({ userId, newNotice: new Date(), noticeRead: new Date() })
+    await Notice.create({
+      userId,
+      newNotice: null,
+      noticeRead: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    })
     return false
   },
   findAllSubscribers: async userId => {

--- a/socket/helper/index.js
+++ b/socket/helper/index.js
@@ -1,5 +1,5 @@
 // 用來驗證一些基本問題
-const { User, Room } = require('../../models')
+const { User, Room, Notice } = require('../../models')
 const usersInPublic = require('../modules/userOnline')
 const { Op } = require('sequelize')
 
@@ -64,6 +64,13 @@ const helper = {
     rooms.forEach(roomId => {
       socket.join(roomId.toString())
     })
+  },
+  checkNotice: async userId => {
+    const notice = await Notice.findOne({ where: { userId } })
+    // if notice exist
+    if (notice) return notice.newNotice > notice.noticeRead
+    // if there isn't any notice record
+    return false
   }
 }
 module.exports = helper

--- a/socket/index.js
+++ b/socket/index.js
@@ -9,6 +9,8 @@ const enterRoom = require('./modules/enterRoom')
 const leaveRoom = require('./modules/leaveRoom')
 const subscribe = require('./modules/subscribe')
 const unsubscribe = require('./modules/unsubscribe')
+const pushNotice = require('./modules/pushNotice')
+const getNotice = require('./modules/getNotice')
 
 module.exports = io => {
   io.on('connection', socket => {
@@ -38,6 +40,13 @@ module.exports = io => {
     socket.on('client-subscribe', targetId => subscribe(socket, targetId))
     // 取消訂閱
     socket.on('client-unsubscribe', targetId => unsubscribe(socket, targetId))
+
+    // 觸發通知
+    socket.on('client-push-notice', (action, targetId) =>
+      pushNotice(socket, action, targetId)
+    )
+    // 取得通知
+    socket.on('client-get-notice', () => getNotice(socket))
 
     // 使用者斷線
     socket.on('disconnect', reason => disconnect(socket, reason))

--- a/socket/modules/getNotice.js
+++ b/socket/modules/getNotice.js
@@ -1,0 +1,11 @@
+const {
+  emitError
+} = require('../helper')
+
+module.exports = async socket => {
+  try {
+    console.log('觸發get notice')
+  } catch (err) {
+    emitError(socket, err)
+  }
+}

--- a/socket/modules/join.js
+++ b/socket/modules/join.js
@@ -5,7 +5,8 @@ const {
   findUserIndexInPublic,
   getAllRooms,
   findUserInPublic,
-  joinAllRooms
+  joinAllRooms,
+  checkNotice
 } = require('../helper')
 
 module.exports = async (io, socket, userId) => {
@@ -14,7 +15,7 @@ module.exports = async (io, socket, userId) => {
     const user = await userExistInDB(userId, 'id')
     const index = await findUserIndexInPublic(userId, 'id')
     const rooms = await getAllRooms(userId)
-
+    const unreadNotice = await checkNotice(userId)
     // clear timeout if any
     const userOnList = findUserInPublic(userId, 'id', false)
     if (userOnList?.timeout) {
@@ -26,6 +27,7 @@ module.exports = async (io, socket, userId) => {
     // update
     user.socketId = socket.id
     user.rooms = rooms
+    user.unreadNotice = unreadNotice
 
     if (index === -1) {
       usersInPublic.push(user)
@@ -42,6 +44,7 @@ module.exports = async (io, socket, userId) => {
     // 更新上線名單
     io.emit('server-update', usersInPublic)
     console.log(usersInPublic)
+    console.log(user)
   } catch (err) {
     emitError(socket, err)
   }

--- a/socket/modules/newMessage.js
+++ b/socket/modules/newMessage.js
@@ -7,7 +7,6 @@ module.exports = async socket => {
     console.log('Trigger new Message')
     // 確認使用者是否登入
     const currentUser = findUserInPublic(socket.id, 'socketId')
-    console.log('User:', currentUser)
     // 找出目前登入的使用者所有的room
     const rooms = currentUser.rooms
 

--- a/socket/modules/pushNotice.js
+++ b/socket/modules/pushNotice.js
@@ -1,0 +1,45 @@
+const {
+  emitError,
+  findUserInPublic,
+  findAllSubscribers
+} = require('../helper')
+const { Subscribe, Notice } = require('../../models')
+const { Op } = require('sequelize')
+
+module.exports = async (socket, action, targetId) => {
+  try {
+    // 確認使用者是否登入
+    const currentUser = findUserInPublic(socket.id, 'socketId')
+    // 找出目前登入的使用者所有的room
+    const rooms = currentUser.rooms
+
+    // 當user新增一筆推文時
+    if (action === 'tweet') {
+      // 找出當前使用者的所有訂戶
+      const subscribers = await findAllSubscribers(currentUser.id)
+      console.log('sub:', subscribers)
+      // 更新訂戶的newNotice時間
+      await Notice.update(
+        { newNotice: new Date() },
+        {
+          where: { userId: { [Op.in]: subscribers } }
+        }
+      )
+    }
+
+    // 對某人的tweet回覆、Like或追蹤某人
+    if (['like', 'reply', 'follow'].includes(action)) {
+      await Notice.update(
+        { newNotice: new Date() },
+        {
+          where: { userId: targetId }
+        }
+      )
+    }
+
+    // 提醒有新通知
+    socket.emit('server-push-notice', 'new notice!')
+  } catch (err) {
+    emitError(socket, err)
+  }
+}

--- a/socket/modules/pushNotice.js
+++ b/socket/modules/pushNotice.js
@@ -1,44 +1,69 @@
 const {
   emitError,
   findUserInPublic,
-  findAllSubscribers
+  findAllSubscribers,
+  checkNotice
 } = require('../helper')
-const { Subscribe, Notice } = require('../../models')
+const { Notice } = require('../../models')
 const { Op } = require('sequelize')
+const usersOnline = require('../modules/userOnline')
+const getNotice = require('../modules/getNotice')
 
 module.exports = async (socket, action, targetId) => {
   try {
     // 確認使用者是否登入
     const currentUser = findUserInPublic(socket.id, 'socketId')
-    // 找出目前登入的使用者所有的room
-    const rooms = currentUser.rooms
+    const actions = ['tweet', 'like', 'reply', 'follow']
 
-    // 當user新增一筆推文時
-    if (action === 'tweet') {
-      // 找出當前使用者的所有訂戶
-      const subscribers = await findAllSubscribers(currentUser.id)
-      console.log('sub:', subscribers)
-      // 更新訂戶的newNotice時間
-      await Notice.update(
-        { newNotice: new Date() },
-        {
-          where: { userId: { [Op.in]: subscribers } }
+    if (actions.includes(action)) {
+      // 當user新增一筆推文時
+      if (action === 'tweet') {
+        // 找出當前使用者的所有訂戶
+        const subscribers = await findAllSubscribers(currentUser.id)
+        // 更新訂戶的newNotice時間
+        await Notice.update(
+          { newNotice: new Date() },
+          {
+            where: { userId: { [Op.in]: subscribers } }
+          }
+        )
+        console.log(`NewNotices of userId:${currentUser.id}'s subscribers have updated.`)
+
+        usersOnline.forEach(u => {
+          // find online subscribers
+          if (subscribers.includes(u.id)) {
+            // send new notice message
+            if (u.currentRoom && u.currentRoom === 'notice') {
+              getNotice(socket)
+            }
+            u.unreadNotice = checkNotice(u.id)
+            socket.to(u.socketId).emit('server-push-notice', 'new notice!')
+          }
+        })
+      } else {
+        // 對某人的tweet reply、like或follow某人
+        if (!targetId) throw new Error('targetId is required!')
+        // 更新targetUser的notice
+        await Notice.update(
+          { newNotice: new Date() },
+          {
+            where: { userId: targetId }
+          }
+        )
+        console.log(`NewNotice of userId:${targetId} has updated.`)
+        const targetUserOnline = usersOnline.find(u => u.id.toString() === targetId)
+        // if targetUser online, send new notice message
+        if (targetUserOnline) {
+          if (targetUserOnline.currentRoom && targetUserOnline.currentRoom === 'notice') {
+            // if user in notice, trigger getNotice
+            getNotice(socket)
+          }
+          socket.to(targetUserOnline.socketId).emit('server-push-notice', 'new notice!')
         }
-      )
+      }
+    } else {
+      throw new Error(`Action: ${action} didn't exist!`)
     }
-
-    // 對某人的tweet回覆、Like或追蹤某人
-    if (['like', 'reply', 'follow'].includes(action)) {
-      await Notice.update(
-        { newNotice: new Date() },
-        {
-          where: { userId: targetId }
-        }
-      )
-    }
-
-    // 提醒有新通知
-    socket.emit('server-push-notice', 'new notice!')
   } catch (err) {
     emitError(socket, err)
   }


### PR DESCRIPTION
新增：
1. helpers 新增兩個function : checkNotice, findAllSubscribers 用來判斷是否有未讀訊息及抓取所有subscribers
2. 新增notice 種子資料
3. 使用者註冊帳號時就會產生專屬的notice data，加上有種子資料，所以目前不會遇到找不到notice的問題
4. join之後user的資料會多一個unreadNotice(boolean)的屬性，如果是true代表有未讀訊息
5. client-push-notice事件
  a. 前端需傳入(action, targetId)，action僅能輸入['tweet', 'like', 'reply', 'follow']，不然會拋出error
  b. 若action是tweet，可不用帶入targetId並更新所有訂閱currentUser的subscribers的notice.newNotice
  c. 若action為其他，須帶targetId，並更新targetId的notice.newNotice
  d. 有加入currentRoom是否為'notice'的判斷式，若為true則會觸發getNotice (待完成)

